### PR TITLE
Move initial boot-timer timestamp

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -305,6 +305,10 @@ pub fn build_microvm_for_boot(
     seccomp_filters: &BpfThreadMap,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
     use self::StartMicrovmError::*;
+
+    // Timestamp for measuring microVM boot duration.
+    let request_ts = TimestampUs::default();
+
     let boot_config = vm_resources.boot_source().ok_or(MissingKernelConfig)?;
 
     let track_dirty_pages = vm_resources.track_dirty_pages();
@@ -321,9 +325,6 @@ pub fn build_microvm_for_boot(
     // Clone the command-line so that a failed boot doesn't pollute the original.
     #[allow(unused_mut)]
     let mut boot_cmdline = boot_config.cmdline.clone();
-
-    // Timestamp for measuring microVM boot duration.
-    let request_ts = TimestampUs::default();
 
     let (mut vmm, mut vcpus) = create_vmm_and_vcpus(
         instance_info,


### PR DESCRIPTION
The initial timestamp passed to the boot-timer to calculate uVM boot time
was taken after creating guest memory, loading the kernel, and loading the initrd, and these
should be included in the overall boot time.

# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
